### PR TITLE
Fix bug in LootTableEvents.Replace impl

### DIFF
--- a/src/main/java/com/axialeaa/florumsporum/item/LootTableModifications.java
+++ b/src/main/java/com/axialeaa/florumsporum/item/LootTableModifications.java
@@ -24,7 +24,7 @@ public class LootTableModifications {
 
     private static LootTable registerPandaSneeze(ResourceKey<LootTable> registryKey, LootTable original, LootTableSource source, HolderLookup.Provider holderLookup) {
         if (!validateLootTable(registryKey, BuiltInLootTables.PANDA_SNEEZE, source))
-            return original;
+            return null;
 
         return LootTable.lootTable()
             .withPool(LootPool.lootPool()


### PR DESCRIPTION
Return null so that the mod doesn't replace every loot table loaded by the game :)